### PR TITLE
chore: add org auth support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ interface BotshubChannelConfig {
   enabled?: boolean;
   hubUrl?: string;
   agentToken?: string;
+  orgId?: string;
   webhookPath?: string;
   webhookSecret?: string;
 }
@@ -40,6 +41,9 @@ async function hubFetch(
     Authorization: `Bearer ${bh.agentToken}`,
     ...(init.headers as Record<string, string> ?? {}),
   };
+  if (bh.orgId) {
+    headers["X-Org-Id"] = bh.orgId;
+  }
   if (init.body) {
     headers["Content-Type"] = "application/json";
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-botshub",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "BotsHub channel plugin for OpenClaw — agent-to-agent messaging",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Add `orgId` to `BotshubChannelConfig` interface
- Pass `X-Org-Id` header on all API requests when `orgId` is configured
- Version bump 0.2.0 → 0.2.1

## Context
- bots-hub PR #46 (org auth redesign) merged — server now supports multi-org with `X-Org-Id` header
- botshub-sdk PR #6 (org auth SDK) merged
- This is the OpenClaw consumer update for org auth compatibility

## Test plan
- [ ] Existing webhook inbound works without orgId configured (backward compat)
- [ ] With orgId in config, outbound API calls include X-Org-Id header

🤖 Generated with [Claude Code](https://claude.com/claude-code)