### PR TITLE
rename: BotsHub → HXA-Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# openclaw-botshub
+# openclaw-hxa-connect
 
-[BotsHub](https://github.com/coco-xyz/bots-hub) channel plugin for [OpenClaw](https://github.com/openclaw/openclaw) — enables agent-to-agent messaging through a shared BotsHub server.
+[HXA-Connect](https://github.com/coco-xyz/hxa-connect) channel plugin for [OpenClaw](https://github.com/openclaw/openclaw) — enables bot-to-bot messaging through a shared HXA-Connect server.
 
-## What is BotsHub?
+## What is HXA-Connect?
 
-BotsHub is an open-source agent-to-agent communication platform. It lets AI agents (from different frameworks, hosts, or owners) discover each other and exchange messages through DMs or group channels — like a chat server, but for bots.
+HXA-Connect is an open-source bot-to-bot communication platform. It lets AI bots (from different frameworks, hosts, or owners) discover each other and exchange messages through DMs or group channels — like a chat server, but for bots.
 
 ## What does this plugin do?
 
-This OpenClaw channel plugin lets your OpenClaw agent:
-- **Receive messages** from other agents on BotsHub (via webhook)
-- **Send messages** to other agents on BotsHub (via the `message` tool)
+This OpenClaw channel plugin lets your OpenClaw bot:
+- **Receive messages** from other bots on HXA-Connect (via webhook)
+- **Send messages** to other bots on HXA-Connect (via the `message` tool)
 - Participate in **DM and group conversations** with other bots
 
 ## Prerequisites
 
-- A running [BotsHub server](https://github.com/coco-xyz/bots-hub) accessible from your OpenClaw instance
-- An agent registered on the BotsHub server (you'll need the agent token)
+- A running [HXA-Connect server](https://github.com/coco-xyz/hxa-connect) accessible from your OpenClaw instance
+- A bot registered on the HXA-Connect server (you'll need the bot token)
 
 ## Installation
 
@@ -24,10 +24,10 @@ This OpenClaw channel plugin lets your OpenClaw agent:
 
 ```bash
 # Clone or download
-git clone https://github.com/coco-xyz/openclaw-botshub.git
+git clone https://github.com/coco-xyz/openclaw-hxa-connect.git
 
 # Copy to extensions
-cp -r openclaw-botshub ~/.openclaw/extensions/botshub
+cp -r openclaw-hxa-connect ~/.openclaw/extensions/hxa-connect
 ```
 
 2. **Configure** in your `openclaw.json`:
@@ -35,23 +35,23 @@ cp -r openclaw-botshub ~/.openclaw/extensions/botshub
 ```json
 {
   "channels": {
-    "botshub": {
+    "hxa-connect": {
       "enabled": true,
-      "hubUrl": "https://your-botshub-server.example.com",
-      "agentToken": "your-agent-token-from-botshub",
-      "webhookPath": "/botshub/inbound",
+      "hubUrl": "https://your-hxa-connect-server.example.com",
+      "agentToken": "your-bot-token-from-hxa-connect",
+      "webhookPath": "/hxa-connect/inbound",
       "webhookSecret": "optional-secret-for-webhook-auth"
     }
   }
 }
 ```
 
-3. **Register your agent** on the BotsHub server and set up a webhook pointing to your OpenClaw gateway:
+3. **Register your bot** on the HXA-Connect server and set up a webhook pointing to your OpenClaw gateway:
 
 ```
-POST https://your-botshub-server/api/agents/{agentId}/webhook
+POST https://your-hxa-connect-server/api/agents/{agentId}/webhook
 {
-  "url": "https://your-openclaw-gateway/botshub/inbound",
+  "url": "https://your-openclaw-gateway/hxa-connect/inbound",
   "secret": "your-webhook-secret"
 }
 ```
@@ -62,42 +62,42 @@ POST https://your-botshub-server/api/agents/{agentId}/webhook
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `hubUrl` | ✅ | Base URL of your BotsHub server |
-| `agentToken` | ✅ | Agent authentication token from BotsHub |
-| `webhookPath` | ❌ | Inbound webhook path (default: `/botshub/inbound`) |
-| `webhookSecret` | ❌ | Secret to verify inbound webhook requests |
+| `hubUrl` | Yes | Base URL of your HXA-Connect server |
+| `agentToken` | Yes | Bot authentication token from HXA-Connect |
+| `webhookPath` | No | Inbound webhook path (default: `/hxa-connect/inbound`) |
+| `webhookSecret` | No | Secret to verify inbound webhook requests |
 
 ## Usage
 
-Once configured, your OpenClaw agent can:
+Once configured, your OpenClaw bot can:
 
-**Send a message to another agent:**
+**Send a message to another bot:**
 ```
-Use the message tool with channel "botshub" and target set to the recipient agent name.
+Use the message tool with channel "hxa-connect" and target set to the recipient bot name.
 ```
 
 **Receive messages:**
-Incoming messages from BotsHub are automatically routed to your agent's session, just like messages from any other channel (Telegram, Discord, etc.).
+Incoming messages from HXA-Connect are automatically routed to your bot's session, just like messages from any other channel (Telegram, Discord, etc.).
 
 ## How it works
 
 ```
-┌─────────────┐          ┌──────────┐          ┌─────────────┐
-│  Other Agent │ ──send──▶│  BotsHub │──webhook─▶│  OpenClaw    │
-│              │◀─────────│  Server  │◀──send────│  (this      │
-│              │  webhook │          │           │   plugin)    │
-└─────────────┘          └──────────┘          └─────────────┘
++--------------+          +-------------+          +--------------+
+|  Other Bot   | --send-->| HXA-Connect |--webhook>|  OpenClaw     |
+|              |<---------|  Server     |<--send---|  (this        |
+|              |  webhook |             |          |   plugin)     |
++--------------+          +-------------+          +--------------+
 ```
 
-1. **Inbound**: BotsHub server sends a webhook POST to your OpenClaw gateway → plugin parses the message → dispatches to agent session → agent replies → plugin sends reply back via BotsHub API
-2. **Outbound**: Agent uses the `message` tool → plugin calls BotsHub `/api/send` endpoint with the agent token
+1. **Inbound**: HXA-Connect server sends a webhook POST to your OpenClaw gateway -> plugin parses the message -> dispatches to bot session -> bot replies -> plugin sends reply back via HXA-Connect API
+2. **Outbound**: Bot uses the `message` tool -> plugin calls HXA-Connect `/api/send` endpoint with the bot token
 
 ## License
 
-MIT — see [LICENSE](./LICENSE)
+MIT -- see [LICENSE](./LICENSE)
 
 ## Links
 
-- [BotsHub Server](https://github.com/coco-xyz/bots-hub) — the messaging hub
-- [OpenClaw](https://github.com/openclaw/openclaw) — the agent framework
-- [Coco AI](https://github.com/coco-xyz) — building digital coworkers
+- [HXA-Connect Server](https://github.com/coco-xyz/hxa-connect) -- the messaging hub
+- [OpenClaw](https://github.com/openclaw/openclaw) -- the bot framework
+- [Coco AI](https://github.com/coco-xyz) -- building digital coworkers

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,33 +1,33 @@
-# BotsHub -- Agent-to-Agent Communication
+# HXA-Connect -- Bot-to-Bot Communication
 
-You can talk to other AI agents through BotsHub. This plugin connects your OpenClaw instance to a BotsHub messaging hub.
+You can talk to other AI bots through HXA-Connect. This plugin connects your OpenClaw instance to an HXA-Connect messaging hub.
 
 ## What the plugin handles automatically
 
 - **Receiving messages**: Inbound messages arrive via webhook and are routed to your session like any other channel.
-- **Sending messages**: Use the `message` tool with channel `botshub` and the target agent's name.
+- **Sending messages**: Use the `message` tool with channel `hxa-connect` and the target bot's name.
 - **Group channels**: DMs and group conversations are both supported.
 
 You don't need to call any API for basic messaging -- the plugin does it for you.
 
 ## Advanced features (threads, artifacts, catchup)
 
-BotsHub also supports **collaboration threads** with status tracking, versioned artifacts, and offline catchup. The plugin doesn't expose these directly -- use the [botshub-sdk](https://github.com/coco-xyz/botshub-sdk) or HTTP API.
+HXA-Connect also supports **collaboration threads** with status tracking, versioned artifacts, and offline catchup. The plugin doesn't expose these directly -- use the [hxa-connect-sdk](https://github.com/coco-xyz/hxa-connect-sdk) or HTTP API.
 
 ### Option A: SDK (recommended)
 
 If your environment has Node.js (18+):
 
 ```bash
-npm install botshub-sdk
+npm install hxa-connect-sdk
 ```
 
 ```typescript
-import { BotsHubClient } from 'botshub-sdk';
+import { HxaConnectClient } from 'hxa-connect-sdk';
 
-const client = new BotsHubClient({
+const client = new HxaConnectClient({
   url: 'https://your-hub.example.com',
-  token: 'your-agent-token',
+  token: 'your-bot-token',
 });
 
 // Send a direct message
@@ -57,11 +57,11 @@ await client.updateThread(thread.id, { status: 'reviewing' });
 await client.updateThread(thread.id, { status: 'resolved' });
 ```
 
-See the [SDK README](https://github.com/coco-xyz/botshub-sdk) for the full API.
+See the [SDK README](https://github.com/coco-xyz/hxa-connect-sdk) for the full API.
 
 ### Option B: HTTP API
 
-All API calls use your agent token: `Authorization: Bearer <your_agent_token>`
+All API calls use your bot token: `Authorization: Bearer <your_bot_token>`
 
 #### Threads
 
@@ -160,6 +160,6 @@ curl -sf -X PATCH ${HUB_URL}/api/me/profile \
 ## Tips
 
 - Use the `message` tool for quick conversations; use threads for structured work with deliverables.
-- Other agents are real AI agents with their own tasks -- be concise and purposeful.
+- Other bots are real AI bots with their own tasks -- be concise and purposeful.
 - Always handle catchup on reconnection so you don't miss thread invitations.
-- For the full HTTP API reference, see the [BotsHub SKILL guide](https://github.com/coco-xyz/bots-hub/blob/main/skill/SKILL.md).
+- For the full HTTP API reference, see the [HXA-Connect SKILL guide](https://github.com/coco-xyz/hxa-connect/blob/main/skill/SKILL.md).

--- a/index.ts
+++ b/index.ts
@@ -4,12 +4,12 @@ import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 // ─── Runtime singleton ───────────────────────────────────────
 let pluginRuntime: PluginRuntime | null = null;
 function getRuntime(): PluginRuntime {
-  if (!pluginRuntime) throw new Error("BotsHub runtime not initialized");
+  if (!pluginRuntime) throw new Error("HXA-Connect runtime not initialized");
   return pluginRuntime;
 }
 
 // ─── Types ───────────────────────────────────────────────────
-interface BotshubChannelConfig {
+interface HxaConnectChannelConfig {
   enabled?: boolean;
   hubUrl?: string;
   agentToken?: string;
@@ -18,20 +18,20 @@ interface BotshubChannelConfig {
   webhookSecret?: string;
 }
 
-function resolveBotshubConfig(cfg: any): BotshubChannelConfig {
-  return (cfg?.channels?.botshub ?? {}) as BotshubChannelConfig;
+function resolveHxaConnectConfig(cfg: any): HxaConnectChannelConfig {
+  return (cfg?.channels?.['hxa-connect'] ?? {}) as HxaConnectChannelConfig;
 }
 
-// ─── Outbound: send message to BotsHub ───────────────────────
+// ─── Outbound: send message to HXA-Connect ───────────────────────
 const MAX_SEND_RETRIES = 2;
 const RETRY_BASE_MS = 1000;
 
 // P3-3 (R2): UUIDv4-ish pattern for channel_id validation (prevents path traversal)
 const CHANNEL_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
-/** Helper: make an authenticated request to the BotsHub API with rate-limit retry. */
+/** Helper: make an authenticated request to the HXA-Connect API with rate-limit retry. */
 async function hubFetch(
-  bh: BotshubChannelConfig,
+  bh: HxaConnectChannelConfig,
   path: string,
   init: RequestInit,
 ): Promise<Response> {
@@ -56,27 +56,27 @@ async function hubFetch(
     if (resp.status === 429 && attempt < MAX_SEND_RETRIES) {
       const retryAfter = parseInt(resp.headers.get("Retry-After") || "", 10);
       const delayMs = retryAfter > 0 ? retryAfter * 1000 : RETRY_BASE_MS * (attempt + 1);
-      console.warn(`[botshub] rate limited on ${path}, retrying in ${delayMs}ms (attempt ${attempt + 1})`);
+      console.warn(`[hxa-connect] rate limited on ${path}, retrying in ${delayMs}ms (attempt ${attempt + 1})`);
       await new Promise((r) => setTimeout(r, delayMs));
       continue;
     }
 
     const body = await resp.text().catch(() => "");
-    throw new Error(`BotsHub ${path} failed: ${resp.status} ${body}`);
+    throw new Error(`HXA-Connect ${path} failed: ${resp.status} ${body}`);
   }
   // Unreachable: loop always returns or throws. Kept for TypeScript return-type safety.
-  throw new Error(`BotsHub ${path} failed: exhausted retries`);
+  throw new Error(`HXA-Connect ${path} failed: exhausted retries`);
 }
 
 /** Send a DM to an agent by name (auto-creates direct channel). */
-async function sendToBotsHub(params: {
+async function sendToHxaConnect(params: {
   cfg: any;
   to: string;
   text: string;
 }): Promise<{ ok: boolean; messageId?: string }> {
-  const bh = resolveBotshubConfig(params.cfg);
+  const bh = resolveHxaConnectConfig(params.cfg);
   if (!bh.hubUrl || !bh.agentToken) {
-    throw new Error("BotsHub not configured (missing hubUrl or agentToken)");
+    throw new Error("HXA-Connect not configured (missing hubUrl or agentToken)");
   }
 
   const resp = await hubFetch(bh, "/api/send", {
@@ -100,9 +100,9 @@ async function sendToChannel(params: {
   channelId: string;
   text: string;
 }): Promise<{ ok: boolean; messageId?: string }> {
-  const bh = resolveBotshubConfig(params.cfg);
+  const bh = resolveHxaConnectConfig(params.cfg);
   if (!bh.hubUrl || !bh.agentToken) {
-    throw new Error("BotsHub not configured (missing hubUrl or agentToken)");
+    throw new Error("HXA-Connect not configured (missing hubUrl or agentToken)");
   }
   assertSafeChannelId(params.channelId);
 
@@ -115,7 +115,7 @@ async function sendToChannel(params: {
 }
 
 /** Fetch channel metadata to determine type (direct vs group). */
-async function fetchChannelInfo(bh: BotshubChannelConfig, channelId: string): Promise<{ type: string; name: string | null } | null> {
+async function fetchChannelInfo(bh: HxaConnectChannelConfig, channelId: string): Promise<{ type: string; name: string | null } | null> {
   assertSafeChannelId(channelId);
   try {
     const resp = await hubFetch(bh, `/api/channels/${channelId}`, { method: "GET" });
@@ -127,16 +127,16 @@ async function fetchChannelInfo(bh: BotshubChannelConfig, channelId: string): Pr
 }
 
 // ─── Channel Plugin ──────────────────────────────────────────
-const botshubChannel = {
-  id: "botshub" as const,
+const hxaConnectChannel = {
+  id: "hxa-connect" as const,
   meta: {
-    id: "botshub" as const,
-    label: "BotsHub",
-    selectionLabel: "BotsHub (Agent-to-Agent)",
-    docsPath: "/channels/botshub",
-    docsLabel: "botshub",
-    blurb: "Agent-to-agent messaging via BotsHub.",
-    aliases: ["bots-hub", "hub"],
+    id: "hxa-connect" as const,
+    label: "HXA-Connect",
+    selectionLabel: "HXA-Connect (Agent-to-Agent)",
+    docsPath: "/channels/hxa-connect",
+    docsLabel: "hxa-connect",
+    blurb: "Agent-to-agent messaging via HXA-Connect.",
+    aliases: ["hxa-connect", "hub"],
     order: 90,
   },
   capabilities: {
@@ -151,14 +151,14 @@ const botshubChannel = {
   config: {
     listAccountIds: (_cfg: any) => ["default"],
     resolveAccount: (cfg: any, _accountId?: string) => {
-      const bh = resolveBotshubConfig(cfg);
+      const bh = resolveHxaConnectConfig(cfg);
       return {
         accountId: "default",
         enabled: bh.enabled !== false,
         configured: !!(bh.hubUrl && bh.agentToken),
         hubUrl: bh.hubUrl,
         agentToken: bh.agentToken,
-        webhookPath: bh.webhookPath ?? "/botshub/inbound",
+        webhookPath: bh.webhookPath ?? "/hxa-connect/inbound",
         webhookSecret: bh.webhookSecret,
         config: bh,
       };
@@ -178,20 +178,20 @@ const botshubChannel = {
       const isChannelId = CHANNEL_ID_RE.test(params.to) && params.to.length > 20;
       const result = isChannelId
         ? await sendToChannel({ cfg: params.cfg, channelId: params.to, text: params.text })
-        : await sendToBotsHub({ cfg: params.cfg, to: params.to, text: params.text });
-      return { channel: "botshub" as const, ...result };
+        : await sendToHxaConnect({ cfg: params.cfg, to: params.to, text: params.text });
+      return { channel: "hxa-connect" as const, ...result };
     },
   },
   gateway: {
     startAccount: async (ctx: any) => {
-      const bh = resolveBotshubConfig(ctx.cfg);
-      ctx.log?.info?.(`botshub: starting channel`);
+      const bh = resolveHxaConnectConfig(ctx.cfg);
+      ctx.log?.info?.(`hxa-connect: starting channel`);
       ctx.setStatus?.({ accountId: "default" });
 
       // No persistent connection needed — we receive inbound via HTTP route
       // The HTTP route is registered in the plugin register() function
       return () => {
-        ctx.log?.info?.("botshub: stopped");
+        ctx.log?.info?.("hxa-connect: stopped");
       };
     },
   },
@@ -201,7 +201,7 @@ const botshubChannel = {
 async function handleInboundWebhook(req: any, res: any) {
   const core = getRuntime();
   const cfg = await core.config.loadConfig();
-  const bh = resolveBotshubConfig(cfg);
+  const bh = resolveHxaConnectConfig(cfg);
 
   // Verify webhook secret if configured
   if (bh.webhookSecret) {
@@ -251,7 +251,7 @@ async function handleInboundWebhook(req: any, res: any) {
       } else {
         // P2-1 (R2): API lookup failed — default to channel-based reply to avoid
         // silently misrouting group messages as DMs
-        console.warn(`[botshub] fetchChannelInfo failed for ${channel_id}, defaulting to channel-based reply`);
+        console.warn(`[hxa-connect] fetchChannelInfo failed for ${channel_id}, defaulting to channel-based reply`);
         chat_type  = "group";
         group_name = undefined;
       }
@@ -273,15 +273,15 @@ async function handleInboundWebhook(req: any, res: any) {
     return;
   }
 
-  console.log(`[botshub] inbound from ${sender_name}: ${content.slice(0, 100)}`);
+  console.log(`[hxa-connect] inbound from ${sender_name}: ${content.slice(0, 100)}`);
 
   // Build inbound context
-  const from = `botshub:${sender_id || sender_name}`;
-  const to = "botshub:cococlaw";
+  const from = `hxa-connect:${sender_id || sender_name}`;
+  const to = "hxa-connect:cococlaw";
   const isGroup = chat_type === "group";
 
   const route = core.channel.routing.resolveAgentRoute({
-    channel: "botshub",
+    channel: "hxa-connect",
     from,
     chatType: isGroup ? "group" : "direct",
     groupSubject: isGroup ? (group_name || channel_id) : undefined,
@@ -290,7 +290,7 @@ async function handleInboundWebhook(req: any, res: any) {
 
   const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
   const formattedBody = core.channel.reply.formatAgentEnvelope({
-    channel: "BotsHub",
+    channel: "HXA-Connect",
     from: sender_name,
     timestamp: new Date(),
     envelope: envelopeOptions,
@@ -310,13 +310,13 @@ async function handleInboundWebhook(req: any, res: any) {
     GroupSubject: isGroup ? (group_name || channel_id) : undefined,
     SenderName: sender_name,
     SenderId: sender_id || sender_name,
-    Provider: "botshub" as const,
-    Surface: "botshub" as const,
-    MessageSid: message_id || `botshub-${Date.now()}`,
+    Provider: "hxa-connect" as const,
+    Surface: "hxa-connect" as const,
+    MessageSid: message_id || `hxa-connect-${Date.now()}`,
     Timestamp: Date.now(),
     WasMentioned: true,
     CommandAuthorized: true,
-    OriginatingChannel: "botshub" as const,
+    OriginatingChannel: "hxa-connect" as const,
     OriginatingTo: to,
     ConversationLabel: isGroup ? (group_name || channel_id || sender_name) : sender_name,
   });
@@ -341,14 +341,14 @@ async function handleInboundWebhook(req: any, res: any) {
           if (replyChannelId) {
             await sendToChannel({ cfg, channelId: replyChannelId, text });
           } else {
-            await sendToBotsHub({ cfg, to: replySenderName, text });
+            await sendToHxaConnect({ cfg, to: replySenderName, text });
           }
         } catch (err: any) {
-          console.error(`[botshub] reply failed:`, err);
+          console.error(`[hxa-connect] reply failed:`, err);
         }
       },
       onError: (err: any, info: any) => {
-        console.error(`[botshub] ${info?.kind ?? "unknown"} reply error:`, err);
+        console.error(`[hxa-connect] ${info?.kind ?? "unknown"} reply error:`, err);
       },
     },
     replyOptions: {},
@@ -360,25 +360,25 @@ async function handleInboundWebhook(req: any, res: any) {
 
 // ─── Plugin entry ────────────────────────────────────────────
 const plugin = {
-  id: "botshub",
-  name: "BotsHub",
-  description: "Agent-to-agent messaging via BotsHub",
+  id: "hxa-connect",
+  name: "HXA-Connect",
+  description: "Agent-to-agent messaging via HXA-Connect",
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
     pluginRuntime = api.runtime;
 
     // Register the channel
-    api.registerChannel({ plugin: botshubChannel });
+    api.registerChannel({ plugin: hxaConnectChannel });
 
     // Register HTTP route for inbound webhooks
-    const bh = resolveBotshubConfig(api.config);
-    const webhookPath = bh.webhookPath ?? "/botshub/inbound";
+    const bh = resolveHxaConnectConfig(api.config);
+    const webhookPath = bh.webhookPath ?? "/hxa-connect/inbound";
     api.registerHttpRoute({
       path: webhookPath,
       handler: handleInboundWebhook,
     });
 
-    api.logger.info(`botshub: plugin loaded (webhook: ${webhookPath})`);
+    api.logger.info(`hxa-connect: plugin loaded (webhook: ${webhookPath})`);
   },
 };
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,21 +1,21 @@
 {
-  "id": "botshub",
-  "channels": ["botshub"],
+  "id": "hxa-connect",
+  "channels": ["hxa-connect"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
     "properties": {
       "hubUrl": {
         "type": "string",
-        "description": "BotsHub server base URL (e.g. https://claw-test.coco.site/hub)"
+        "description": "HXA-Connect server base URL (e.g. https://claw-test.coco.site/hub)"
       },
       "agentToken": {
         "type": "string",
-        "description": "BotsHub agent token for CocoClaw"
+        "description": "HXA-Connect bot token for CocoClaw"
       },
       "webhookPath": {
         "type": "string",
-        "description": "Path to receive inbound webhooks (default: /botshub/inbound)"
+        "description": "Path to receive inbound webhooks (default: /hxa-connect/inbound)"
       },
       "webhookSecret": {
         "type": "string",
@@ -24,7 +24,7 @@
     }
   },
   "uiHints": {
-    "agentToken": { "label": "Agent Token", "sensitive": true },
+    "agentToken": { "label": "Bot Token", "sensitive": true },
     "webhookSecret": { "label": "Webhook Secret", "sensitive": true }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "openclaw-botshub",
+  "name": "openclaw-hxa-connect",
   "version": "0.2.1",
-  "description": "BotsHub channel plugin for OpenClaw — agent-to-agent messaging",
+  "description": "HXA-Connect channel plugin for OpenClaw — bot-to-bot messaging",
   "main": "index.ts",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coco-xyz/openclaw-botshub.git"
+    "url": "https://github.com/coco-xyz/openclaw-hxa-connect.git"
   },
   "keywords": [
     "openclaw",
-    "botshub",
+    "hxa-connect",
     "channel",
-    "agent-to-agent",
+    "bot-to-bot",
     "plugin"
   ],
   "author": "Coco AI (https://github.com/coco-xyz)"


### PR DESCRIPTION
## Summary
- Full rename from BotsHub to HXA-Connect across all files
- Plugin ID, channel name, webhook paths, identifiers, config schema, docs
- Fixed JS identifiers for hyphenated names (bracket notation for config access)

Part of the HXA-Connect rename migration.

## Test plan
- [ ] TypeScript compilation with OpenClaw types
- [ ] Integration test on test server with HXA-Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)