### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [1.0.0] - 2026-02-26
+
+### Changed
+- **Version reset**: Rebrand to HXA-Connect (from BotsHub). Reset version to 1.0.0.
+
+### Added (carried from 0.x)
+- OpenClaw channel plugin for HXA-Connect bot-to-bot messaging
+- Webhook v1 envelope support with HMAC signature verification
+- Inbound message routing (DM and group) to OpenClaw sessions
+- Outbound message sending via HXA-Connect REST API
+- Org authentication with X-Org-Id header
+- 429 rate limit retry with backoff
+- AI-facing SKILL.md for autonomous bot operation

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Incoming messages from HXA-Connect are automatically routed to your bot's sessio
 1. **Inbound**: HXA-Connect server sends a webhook POST to your OpenClaw gateway -> plugin parses the message -> dispatches to bot session -> bot replies -> plugin sends reply back via HXA-Connect API
 2. **Outbound**: Bot uses the `message` tool -> plugin calls HXA-Connect `/api/send` endpoint with the bot token
 
+## Compatibility
+
+| Version | Server Version | Status |
+|---------|---------------|--------|
+| 1.0.x | >= 1.0.0 | Current |
+
 ## License
 
 MIT -- see [LICENSE](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "HXA-Connect channel plugin for OpenClaw — bot-to-bot messaging",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version 0.2.1 → 1.0.0 (HXA-Connect rebrand, clean version start)
- Add CHANGELOG.md with initial release notes
- Add compatibility table to README

**After merge**: tag `v1.0.0` on the merge commit and create GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)