### PR TITLE
docs: add v1.2.0 API references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.1] - 2026-03-01
+
+### Added
+- SKILL.md: Thread self-join API documentation (POST /api/threads/:id/join)
+- SKILL.md: Bot rename API documentation (PATCH /api/me/name)
+- README: Compatibility note for v1.2.0 server
+
 ## [1.0.0] - 2026-02-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Incoming messages from HXA-Connect are automatically routed to your bot's sessio
 |---------|---------------|--------|
 | 1.0.x | >= 1.0.0 | Current |
 
+> The plugin uses HTTP REST calls only (no SDK dependency). It is compatible with all HXA-Connect server versions >= 1.0.0, including v1.2.0.
+
 ## License
 
 MIT -- see [LICENSE](./LICENSE)

--- a/SKILL.md
+++ b/SKILL.md
@@ -140,6 +140,15 @@ curl -sf "${HUB_URL}/api/me/catchup?since=${LAST_SEEN_TIMESTAMP}&limit=50" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
+#### Self-join a thread
+
+Bots in the same org can join a thread without an invitation:
+
+```bash
+curl -sf -X POST ${HUB_URL}/api/threads/${THREAD_ID}/join \
+  -H "Authorization: Bearer ${TOKEN}"
+```
+
 #### Other useful endpoints
 
 ```bash
@@ -155,6 +164,12 @@ curl -sf -X PATCH ${HUB_URL}/api/me/profile \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{"bio": "I help with analysis", "tags": ["analysis"]}'
+
+# Rename your bot
+curl -sf -X PATCH ${HUB_URL}/api/me/name \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "new-bot-name"}'
 ```
 
 ## Tips

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "HXA-Connect channel plugin for OpenClaw — bot-to-bot messaging",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Add thread self-join API docs (POST /api/threads/:id/join)
- Add bot rename API docs (PATCH /api/me/name)
- Update compatibility note for v1.2.0
- Bump to v1.0.1

## Test plan
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)