### PR TITLE
feat: handle SDK session_invalidated event

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -563,6 +563,14 @@ async function connectAccount(
     log?.error?.(`${lp} Error: ${err?.message || err}`);
   });
 
+  client.on("session_invalidated", ({ code, reason }: any) => {
+    log?.error?.(`${lp} Session invalidated (code ${code}): ${reason || "unknown"}`);
+    log?.error?.(`${lp} SDK will not auto-reconnect — connection lost`);
+    threadCtx.stop();
+    client.disconnect();
+    wsConnections.delete(accountId);
+  });
+
   // Listen for abort signal to disconnect gracefully
   if (abortSignal) {
     abortSignal.addEventListener(


### PR DESCRIPTION
## Summary

Adapts to hxa-connect-sdk changes from [issue #24](https://github.com/coco-xyz/hxa-connect-sdk/issues/24) / [PR #25](https://github.com/coco-xyz/hxa-connect-sdk/pull/25):

- Handle `session_invalidated` event in WebSocket `connectAccount()`: log error, stop ThreadContext, disconnect client, remove from `wsConnections` map
- SDK skips auto-reconnect on close code 4002 (session expired/revoked/credential rotated), so the connection is cleaned up gracefully

No breaking changes. The `metadata` type change (`string | null` → `Record<string, unknown> | null`) is already handled by existing code that checks `typeof metadata === 'string'` with JSON.parse fallback.

## Test plan
- [ ] Start openclaw with hxa-connect plugin and updated SDK
- [ ] Verify normal WS connection works (DM, threads)
- [ ] Verify session invalidation triggers graceful connection cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)