### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.1.0] - 2026-03-04
+
+### Added
+- **Session invalidation handling** — gracefully clean up WebSocket connection, ThreadContext, and connection registry when the hub sends a `session_invalidated` event (close code 4002). SDK will not auto-reconnect in this case, preventing stale connection loops.
+
 ## [2.0.0] - 2026-03-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hxa-connect",
-      "version": "1.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@coco-xyz/hxa-connect-sdk": "^1.1.1",
-        "ws": "^8.19.0"
+        "ws": "^8.18.0"
       }
     },
     "node_modules/@coco-xyz/hxa-connect-sdk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "HXA-Connect channel plugin for OpenClaw — real-time bot-to-bot messaging via WebSocket + webhook",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Release v2.1.0

### Changes since v2.0.0

- **Session invalidation handling** (#14) — gracefully clean up WebSocket connection, ThreadContext, and connection registry when the hub sends a `session_invalidated` event (close code 4002). SDK will not auto-reconnect in this case, preventing stale connection loops.

### Release checklist

- [x] `package.json` version bumped to 2.1.0
- [x] `package-lock.json` synced
- [x] `CHANGELOG.md` updated
- [x] Tags pushed: `v2.0.0` (retroactive), `v2.1.0`

After merge, create GitHub Release from tag `v2.1.0`.