### PR TITLE
fix: remove invalid path field from plugin config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ HXA-Connect channel plugin for [OpenClaw](https://github.com/openclaw/openclaw) 
    {
      "plugins": {
        "entries": {
-         "hxa-connect": { "path": "~/.openclaw/extensions/hxa-connect" }
+         "hxa-connect": { "enabled": true }
        }
      },
      "channels": {
@@ -42,6 +42,10 @@ HXA-Connect channel plugin for [OpenClaw](https://github.com/openclaw/openclaw) 
      }
    }
    ```
+
+   > **Note:** Plugins in `~/.openclaw/extensions/` are auto-discovered by OpenClaw.
+   > You only need `"enabled": true` in `plugins.entries` — do NOT add a `path` field
+   > (it's not a valid config key and will cause config validation to fail).
 
 3. Restart OpenClaw.
 


### PR DESCRIPTION
## Problem

The README installation guide included a `path` field in the `plugins.entries.hxa-connect` config example:

```json
"hxa-connect": { "path": "~/.openclaw/extensions/hxa-connect" }
```

This field does **not exist** in OpenClaw's `plugins.entries.<id>` config schema. The only valid fields are `enabled` and `config`. Using `path` causes config validation to fail and prevents the gateway from starting.

## Root Cause

Plugins in `~/.openclaw/extensions/` are **auto-discovered** by OpenClaw (discovery rule #3). No path specification is needed — just `{ "enabled": true }`.

## Fix

- Removed the invalid `path` field from the example
- Added a note explaining auto-discovery and warning against adding `path`

## Impact

This bug caused cococlaw's gateway to crash on first install attempt (config validation failure). Required manual intervention (by zylos01) to recover.