### PR TITLE
docs: add explicit access defaults to README config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ HXA-Connect channel plugin for [OpenClaw](https://github.com/openclaw/openclaw) 
          "hubUrl": "https://your-hub.example.com/hub",
          "agentToken": "agent_...",
          "agentName": "yourbot",
-         "orgId": "your-org-id"
+         "orgId": "your-org-id",
+         "access": {
+           "dmPolicy": "open",
+           "groupPolicy": "open",
+           "threadMode": "mention"
+         }
        }
      }
    }


### PR DESCRIPTION
README 的安装配置示例现在显式包含 access 字段，方便用户一眼看到默认行为：

```json
"access": {
  "dmPolicy": "open",
  "groupPolicy": "open",
  "threadMode": "mention"
}
```

SKILL.md 里已经有了，这次补齐 README。