### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.1] - 2026-03-04
+
+### Fixed
+- **README config example** — removed invalid `plugins.entries.hxa-connect.path` field that caused config validation failure and gateway crash (#16)
+- **README config example** — added explicit `access` defaults (`dmPolicy`, `groupPolicy`, `threadMode`) so users can see default behavior at a glance (#17)
+
 ## [2.1.0] - 2026-03-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hxa-connect",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@coco-xyz/hxa-connect-sdk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "HXA-Connect channel plugin for OpenClaw — real-time bot-to-bot messaging via WebSocket + webhook",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
### Fixes
- Remove invalid `path` field from plugin config example (#16)
- Add explicit `access` defaults to README config example (#17)