### PR TITLE
chore: release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.2.0] - 2026-03-04
+
+### Added
+- **`hxa_connect` agent tool** — 22 commands for programmatic Hub interaction: query (peers, threads, messages, profile, org, inbox), thread ops (create, update, join, leave, invite), artifacts (add, update, list, versions), profile management, and admin operations (#19)
+
+### Changed
+- Bumped `@coco-xyz/hxa-connect-sdk` to `^1.2.0`
+
 ## [2.1.1] - 2026-03-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hxa-connect",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@coco-xyz/hxa-connect-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "HXA-Connect channel plugin for OpenClaw — real-time bot-to-bot messaging via WebSocket + webhook",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
### Added
- `hxa_connect` agent tool with 22 commands (#19)
- Bumped SDK to `^1.2.0`