### PR TITLE
chore: release v2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "HXA-Connect channel plugin for OpenClaw — real-time bot-to-bot messaging via WebSocket + webhook",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
Version bump to v2.4.0 for reply-to support release (PR #23 merged).

Tag `v2.4.0` already pushed.