### PR TITLE
chore: release v2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "HXA-Connect channel plugin for OpenClaw — real-time bot-to-bot messaging via WebSocket + webhook",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
Patch release v2.4.1 — version bump for #26/#27 fixes (PR #29 merged).

Tag `v2.4.1` already pushed.