### PR TITLE
chore: bump version to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.4.1] - 2026-03-05
+
+### Fixed
+- **UUID routing fallback** — separated thread probe from send; only 404 falls back to DM, other errors (401/403/500/network) now throw instead of silently misrouting to DM (#27, #29)
+
+### Added
+- **Webhook reply-to parity** — webhook inbound handler now parses `reply_to_message` (both v1 envelope and legacy format), injects `<replying-to>` tag, and passes reply metadata to `dispatchInbound`, matching WebSocket path behavior (#26, #29)
+
+## [2.4.0] - 2026-03-05
+
+### Added
+- **Reply-to message support** — inbound thread messages with `reply_to_message` now inject `<replying-to>` context tag with sender and content; outbound thread replies automatically include `reply_to` when available (#23)
+- **Reply-to fallback** — if `reply_to` target is deleted (400/NOT_FOUND), message is sent without reply instead of failing (#23)
+
+### Changed
+- Bumped `@coco-xyz/hxa-connect-sdk` from `^1.2.0` to `^1.3.0` (#23)
+
+### Fixed
+- **Sender name escaping** — `replySender` now escapes both `<` and `>` for consistent XML safety (#23)
+- **Dispatcher reply threading** — `dispatchInbound` deliver callback now passes `replyTo` options to `sendToThread` so inbound-driven replies are threaded correctly (#23)
+- **Error enrichment** — `hubFetch` thrown errors now include `status` and `responseBody` for better fallback logic (#23)
+
 ## [2.3.0] - 2026-03-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.2.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hxa-connect",
-      "version": "2.2.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
-        "@coco-xyz/hxa-connect-sdk": "^1.2.0",
+        "@coco-xyz/hxa-connect-sdk": "^1.3.0",
         "ws": "^8.18.0"
       }
     },
     "node_modules/@coco-xyz/hxa-connect-sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@coco-xyz/hxa-connect-sdk/-/hxa-connect-sdk-1.2.0.tgz",
-      "integrity": "sha512-szD3HPJS0Je2tmUOX0RdpvuV6/UowhANYQD72kGJ0LjPiGIMzEz6lpv28UC5gIjQpJMFjJu+zeJ9OyTXzT88bg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@coco-xyz/hxa-connect-sdk/-/hxa-connect-sdk-1.3.0.tgz",
+      "integrity": "sha512-ploIdH/fhl91WZ/sz2N9SAvtPBbsZi3ueiLrbkG/dGuXRzy9vvC09JV6M7FMYdSsQZTxAXwsuzv95Pg5CbvujA==",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "HXA-Connect channel plugin for OpenClaw — real-time bot-to-bot messaging via WebSocket + webhook",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 2.4.1 (package.json + package-lock.json)
- Add CHANGELOG entries for v2.4.0 and v2.4.1

Supersedes PR #30 (which only had package.json bump without CHANGELOG).

## v2.4.0 Changes (PR #23)
- Reply-to message support (inbound + outbound)
- Reply-to fallback on deleted messages
- SDK bump to ^1.3.0
- Sender escaping, dispatcher threading, error enrichment fixes

## v2.4.1 Changes (PR #29)
- UUID routing fallback fix — separated probe from send (#27)
- Webhook reply-to parity (#26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)