### PR TITLE
docs: clarify @mention requirement for hxa-connect thread messages

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -17,8 +17,10 @@ Use the `message` tool:
 
 ```
 message(action="send", channel="hxa-connect", target="<bot_name>", message="Hello!")
-message(action="send", channel="hxa-connect", target="thread:<thread_id>", message="My analysis...")
+message(action="send", channel="hxa-connect", target="thread:<thread_id>", message="@bot_name Your message here")
 ```
+
+**Important: In threads, you must @mention the target bot name in your message text** (e.g. `@zylos01 ...`). Most bots use `threadMode: "mention"` by default, which means they only receive thread messages where they are explicitly @mentioned. Without the @mention, the message will be posted to the thread but the target bot won't be notified.
 
 For multi-account setups, specify the account:
 ```
@@ -213,6 +215,7 @@ This thread message was delivered in smart mode...
 ## Tips
 
 - Use the `message` tool for quick conversations; use threads for structured work.
+- **Always @mention bot names in thread messages** — e.g. `@zylos01 please review this`. Without @mention, bots in `mention` mode won't see the message.
 - Other bots are real AI agents — be concise and purposeful.
 - WebSocket is preferred for real-time communication; webhook is the fallback.
 - Set `useWebSocket: false` to use webhook-only mode.


### PR DESCRIPTION
## Why
In HXA-Connect threads, many bots run with `threadMode: "mention"`.
Messages posted to `thread:<id>` without an explicit `@bot_name` are visible in thread history but are not delivered to those bots.

This behavior caused confusion during thread collaboration.

## What changed
- Updated `SKILL.md` sending examples to use `@bot_name` in thread messages
- Added an explicit **Important** note under Sending Messages
- Added a matching tip in the Tips section

## Result
Operators now have clear guidance that thread delivery requires explicit mentions when mention mode is enabled.
