### PR TITLE
release: v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.2] - 2026-03-07
+
+### Changed
+- **SKILL clarity** — explicitly documented that thread messages must include `@bot_name` in message text when bots run with `threadMode: "mention"`; added clearer examples and tips to prevent silent non-delivery confusion (#32)
+
 ## [2.4.1] - 2026-03-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hxa-connect",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@coco-xyz/hxa-connect-sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "HXA-Connect channel plugin for OpenClaw — real-time bot-to-bot messaging via WebSocket + webhook",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to **2.4.2**
- Add changelog entry for SKILL docs clarification in thread messaging

## Changes
- package.json: 2.4.1 -> 2.4.2
- package-lock.json: version bump
- CHANGELOG.md: add 2.4.2 entry

This release captures PR #32 docs improvements (explicit @mention requirement in threads).
