### PR TITLE
chore: bump @coco-xyz/hxa-connect-sdk to ^1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - **Thread lifecycle events are now silent context by default** — `thread_updated`, `thread_status_changed`, `thread_artifact`, and `thread_participant` no longer dispatch directly into the OpenClaw reply pipeline as standalone turns
 - **SDK-composed lifecycle context** — thread deliveries now read `ThreadContext` lifecycle snapshots and attach them as `<thread-events>` context instead of generating separate replies
+- Bump `@coco-xyz/hxa-connect-sdk` from `^1.5.0` to `^1.6.0` — declares the minimum SDK version providing lifecycle snapshots, delivery reasons, and lifecycle formatting helpers used by this release
 
 ### Fixed
 - **Thread participant noise** — adding or removing a bot from a thread no longer causes every remaining participant bot to emit a natural-language acknowledgement

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
-        "@coco-xyz/hxa-connect-sdk": "^1.5.0",
+        "@coco-xyz/hxa-connect-sdk": "^1.6.0",
         "ws": "^8.18.0"
       }
     },
     "node_modules/@coco-xyz/hxa-connect-sdk": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@coco-xyz/hxa-connect-sdk/-/hxa-connect-sdk-1.5.0.tgz",
-      "integrity": "sha512-Nj4yDOiTnJ0XYYnnlh5sPDLDVRLkznOexdRh0e8iqiTXhp9Xe9Oe7GWOTJoeyAYpu6IWV0+dh8r7r0l4knSeUw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@coco-xyz/hxa-connect-sdk/-/hxa-connect-sdk-1.6.0.tgz",
+      "integrity": "sha512-LkxQ6EYZm0jrYsNoa9b0YzV196M+giAfuKtLg7/VLC6ebGj3UdObv1V83wO1IP8p0HRR+homXs5nqfYGT5zgNw==",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "author": "Coco AI (https://github.com/coco-xyz)",
   "dependencies": {
-    "@coco-xyz/hxa-connect-sdk": "^1.5.0",
+    "@coco-xyz/hxa-connect-sdk": "^1.6.0",
     "ws": "^8.18.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump `@coco-xyz/hxa-connect-sdk` from `^1.5.0` to `^1.6.0`
- refresh `package-lock.json` to install SDK `1.6.0`
- document the new minimum SDK version in the `2.7.0` changelog entry

## Why
- `main` already includes the silent thread lifecycle delivery change and consumes SDK `1.6.0` lifecycle snapshot/reason/formatter capabilities
- the code still degrades gracefully on older SDKs, but the declared minimum dependency should match the actual intended runtime baseline

## Verification
- `npx tsx --test test/*.test.ts`