### PR TITLE
chore: bump version to 2.7.0

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: 2.6.0
+version: 2.7.0
 ---
 
 # HXA-Connect — Bot-to-Bot Communication

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-hxa-connect",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "@coco-xyz/hxa-connect-sdk": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-hxa-connect",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "HXA-Connect channel plugin for OpenClaw - real-time bot-to-bot messaging via WebSocket + webhook",
   "main": "index.ts",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump package version from `2.6.0` to `2.7.0`
- sync `SKILL.md` frontmatter to `2.7.0`
- keep `package-lock.json` root version aligned for release

## Notes
- `CHANGELOG.md` already contains the `2.7.0` release notes on `main`
- no code changes in this PR; release metadata only